### PR TITLE
feat: Enable option to allow remote debugging

### DIFF
--- a/Makefile.maker.yaml
+++ b/Makefile.maker.yaml
@@ -67,6 +67,9 @@ reuse:
 verbatim: |
   tilt: FORCE helm-build-local-image
     tilt up --stream -- --BININFO_VERSION $(BININFO_VERSION) --BININFO_COMMIT_HASH $(BININFO_COMMIT_HASH) --BININFO_BUILD_DATE $(BININFO_BUILD_DATE)
+  
+  tilt-debug: FORCE helm-build-local-image
+	  tilt up --stream -- --BININFO_VERSION $(BININFO_VERSION) --BININFO_COMMIT_HASH $(BININFO_COMMIT_HASH) --BININFO_BUILD_DATE $(BININFO_BUILD_DATE) --TARGET debug
 
   ##@ kubebuilder
 


### PR DESCRIPTION
Provide option with tilt to build docker file with a debug target. This target allows a remote debugger to attach to the process for local debugging purposes.