### PR TITLE
fix(tests): preallocate `devices` to fix linter

### DIFF
--- a/internal/controller/ironcore_controller_test.go
+++ b/internal/controller/ironcore_controller_test.go
@@ -628,7 +628,7 @@ var _ = Describe("Ironcore Controller", func() {
 				}
 				netBoxMock.DCIMMock.(*mock.DCIMMock).GetDevicesByClusterIDFunc = func(clusterID int) ([]models.Device, error) {
 					Expect(clusterID).To(BeElementOf(1))
-					devices := []models.Device{}
+					devices := make([]models.Device, 0, 2)
 					for _, deviceName := range []string{"device-name1", "device-name2"} {
 						devices = append(devices, models.Device{
 							ID:     1,


### PR DESCRIPTION
error:
```
  Error: internal/controller/ironcore_controller_test.go:631:6: Consider preallocating devices with capacity 2 (prealloc)
```