### PR TITLE
LinkHint R7715

### DIFF
--- a/internal/controller/metal3_controller.go
+++ b/internal/controller/metal3_controller.go
@@ -58,7 +58,7 @@ var (
 		"PowerEdge R640":         "en*f1np*",
 		"PowerEdge R660":         "en*f1np*",
 		"PowerEdge R7615":        "en*f*np*",
-		"PowerEdge R7715":        "en*f*np*",
+		"PowerEdge R7715":        "eno*np*",
 		"Proliant DL320 Gen11":   "en*f1np*",
 		"ProLiant DL345 Gen11v2": "en*f1np*",
 	}


### PR DESCRIPTION
    Nics:
      Model:        0x14e4 0x1750
      Name:         eno17105np1
      Speed Gbps:   25
      Model:        0x14e4 0x1750
      Name:         eno17105np1
      Speed Gbps:   25
      Model:        0x14e4 0x1750
      Name:         eno17095np0
      Pxe:          true
      Speed Gbps:   25
      Model:        0x14e4 0x1750
      Name:         eno17095np0
      Pxe:          true
      Speed Gbps:   25