### PR TITLE
fix(ippoolimport): fetch region from resource spec

### DIFF
--- a/internal/controller/ippoolimport_controller.go
+++ b/internal/controller/ippoolimport_controller.go
@@ -237,7 +237,7 @@ func generateIPPoolName(ipPoolSelector *argorav1alpha1.IPPoolSelector, prefix *m
 		return ipPoolSelector.NameOverride, nil
 	}
 	if strings.Contains(prefix.Role.Slug, ComputeTransitPrefixRoleName) {
-		azLetter := strings.TrimPrefix(prefix.Site.Slug, prefix.Site.Region.Slug)
+		azLetter := strings.TrimPrefix(prefix.Site.Slug, strings.ToLower(ipPoolSelector.Region))
 
 		// if contains "compute1" it should be "%s-%s0-%s", if "compute2" it should be "%s-%s1-%s", and so on
 		re := regexp.MustCompile(`(?i)compute(\d+)`)
@@ -246,7 +246,7 @@ func generateIPPoolName(ipPoolSelector *argorav1alpha1.IPPoolSelector, prefix *m
 			if err != nil {
 				return "", err
 			}
-			return fmt.Sprintf("%s-%s%d-%s", ipPoolSelector.NamePrefix, azLetter, computeNum-1, prefix.Site.Region.Slug), nil
+			return fmt.Sprintf("%s-%s%d-%s", ipPoolSelector.NamePrefix, azLetter, computeNum-1, strings.ToLower(ipPoolSelector.Region)), nil
 		}
 	}
 	return fmt.Sprintf("%s-%s", ipPoolSelector.NamePrefix, prefix.Site.Slug), nil

--- a/internal/controller/ippoolimport_controller_test.go
+++ b/internal/controller/ippoolimport_controller_test.go
@@ -495,10 +495,10 @@ var _ = Describe("IPPoolImport Controller", func() {
 
 			computePrefix := "10.10.40.0/24"
 			computeRole := "test-kubernetes-compute-transit"
-			computeSite := "test-eu-1a"
-			computeRegion := "test-eu-1"
+			computeSite := "eu-central-1a"
+			computeRegion := "eu-central-1"
 			computeNamePrefix := "compute"
-			computePoolName := "compute-a0-test-eu-1"
+			computePoolName := "compute-a0-eu-central-1"
 
 			// Create IPPoolImport CR for compute name case
 			computeIPPoolImportCR := &argorav1alpha1.IPPoolImport{
@@ -539,11 +539,6 @@ var _ = Describe("IPPoolImport Controller", func() {
 							ID:   1,
 							Name: computeSite,
 							Slug: computeSite,
-							Region: models.NestedRegion{
-								ID:   1,
-								Name: computeRegion,
-								Slug: computeRegion,
-							},
 						},
 						Vlan: models.NestedVLAN{
 							ID:   1,


### PR DESCRIPTION
It turns out that `/api/dcim/sites/<id>/` does not return the region. Hence we just use same information from the CR spec itself.