### PR TITLE
Fix link hint for ProLiant DL345 Gen11v2

### DIFF
--- a/internal/controller/metal3_controller.go
+++ b/internal/controller/metal3_controller.go
@@ -60,7 +60,7 @@ var (
 		"PowerEdge R7615":        "en*f*np*",
 		"PowerEdge R7715":        "eno*np*",
 		"Proliant DL320 Gen11":   "en*f1np*",
-		"ProLiant DL345 Gen11v2": "en*f1np*",
+		"ProLiant DL345 Gen11v2": "en*f*np*",
 	}
 
 	linkHintMapKvm = map[string]string{


### PR DESCRIPTION
Update interface regex to include new interfaces like: ens3f0np0 and ens3f1np1