### PR TITLE
feat(controller): reconcile BMCSecret on credential rotation

### DIFF
--- a/api/v1alpha1/common.go
+++ b/api/v1alpha1/common.go
@@ -3,6 +3,8 @@
 
 package v1alpha1
 
+const AnnotationIgnore = "argora.cloud.sap/ignore"
+
 type ClusterSelector struct {
 	// +kubebuilder:validation:Optional
 	Name string `json:"name,omitempty"`

--- a/internal/controller/constants.go
+++ b/internal/controller/constants.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+const (
+	deviceStatusActive = "active"
+	deviceStatusStaged = "staged"
+
+	interfaceTypeLag = "lag"
+
+	rootHintBOSS = "BOSS"
+
+	remoteboardInterfaceName = "remoteboard"
+
+	annotationValueTrue = "true"
+)

--- a/internal/controller/ipupdate_controller.go
+++ b/internal/controller/ipupdate_controller.go
@@ -516,7 +516,7 @@ func (r *IPUpdateReconciler) findTargetInterface(interfaces []models.Interface) 
 	re := regexp.MustCompile(`^LAG(\d)$`)
 
 	for _, iface := range interfaces {
-		if strings.ToLower(iface.Type.Value) != "lag" {
+		if strings.ToLower(iface.Type.Value) != interfaceTypeLag {
 			continue
 		}
 

--- a/internal/controller/ironcore_controller.go
+++ b/internal/controller/ironcore_controller.go
@@ -225,6 +225,11 @@ func (r *IronCoreReconciler) reconcileDevice(ctx context.Context, netBox netbox.
 		"kubernetes.metal.cloud.sap/platform":     device.Platform.Slug,
 	}
 
+	bmcSecret, skipped, err := r.reconcileBmcSecret(ctx, device, commonLabels)
+	if err != nil {
+		return fmt.Errorf("unable to reconcile bmc secret: %w", err)
+	}
+
 	bmcObj := &metalv1alpha1.BMC{}
 	if err := r.k8sClient.Get(ctx, client.ObjectKey{Name: device.Name}, bmcObj); err == nil {
 		if err := r.patchBMCLabels(ctx, bmcObj, commonLabels); err != nil {
@@ -234,13 +239,6 @@ func (r *IronCoreReconciler) reconcileDevice(ctx context.Context, netBox netbox.
 		logger.Info("BMC custom resource already exists, will skip", "bmc", device.Name)
 		return nil
 	}
-
-	bmcSecret, err := r.createBmcSecret(ctx, device, commonLabels)
-	if err != nil {
-		return fmt.Errorf("unable to create bmc secret: %w", err)
-	}
-
-	logger.Info("created BMC Secret", "name", bmcSecret.Name)
 
 	hostname, err := getRemoteboardHostname(netBox, device)
 	if err != nil {
@@ -256,46 +254,57 @@ func (r *IronCoreReconciler) reconcileDevice(ctx context.Context, netBox netbox.
 
 	logger.Info("created BMC CR", "name", bmc.Name)
 
-	if err := r.patchOwnerReference(ctx, bmc, bmcSecret); err != nil {
-		return err
+	if !skipped {
+		if err := r.patchOwnerReference(ctx, bmc, bmcSecret); err != nil {
+			return err
+		}
 	}
 	return nil
 }
 
-func (r *IronCoreReconciler) createBmcSecret(ctx context.Context, device *models.Device, labels map[string]string) (*metalv1alpha1.BMCSecret, error) {
+func (r *IronCoreReconciler) reconcileBmcSecret(ctx context.Context, device *models.Device, labels map[string]string) (*metalv1alpha1.BMCSecret, bool, error) {
 	logger := log.FromContext(ctx)
 
 	user := r.credentials.BMCUser
 	password := r.credentials.BMCPassword
 
 	if user == "" || password == "" {
-		return nil, errors.New("bmc user or password not set")
+		return nil, false, errors.New("bmc user or password not set")
 	}
 
 	bmcSecret := &metalv1alpha1.BMCSecret{
-		TypeMeta: ctrl.TypeMeta{
-			APIVersion: metalv1alpha1.GroupVersion.String(),
-			Kind:       "BMCSecret",
-		},
 		ObjectMeta: ctrl.ObjectMeta{
-			Name:   device.Name,
-			Labels: labels,
+			Name: device.Name,
 		},
-		Data: map[string][]byte{
+	}
+
+	if err := r.k8sClient.Get(ctx, client.ObjectKeyFromObject(bmcSecret), bmcSecret); err == nil {
+		if bmcSecret.Annotations[argorav1alpha1.AnnotationIgnore] == "true" {
+			logger.Info("BMCSecret has ignore annotation, skipping reconciliation", "name", bmcSecret.Name)
+			return bmcSecret, true, nil
+		}
+	}
+
+	result, err := controllerutil.CreateOrUpdate(ctx, r.k8sClient, bmcSecret, func() error {
+		bmcSecret.Labels = labels
+		bmcSecret.Data = map[string][]byte{
 			metalv1alpha1.BMCSecretUsernameKeyName: []byte(user),
 			metalv1alpha1.BMCSecretPasswordKeyName: []byte(password),
-		},
-	}
-
-	if err := r.k8sClient.Create(ctx, bmcSecret); err != nil {
-		if apierrors.IsAlreadyExists(err) { // TODO: if its already exists, can we assume that the secret is correct?
-			logger.Info("bmc secret already exists", "bmcSecret", bmcSecret.Name)
-			return bmcSecret, nil
 		}
-		return nil, err
+		return nil
+	})
+	if err != nil {
+		return nil, false, err
 	}
 
-	return bmcSecret, nil
+	switch result {
+	case controllerutil.OperationResultCreated:
+		logger.Info("created BMCSecret", "name", bmcSecret.Name)
+	case controllerutil.OperationResultUpdated:
+		logger.Info("BMCSecret credentials updated", "name", bmcSecret.Name)
+	}
+
+	return bmcSecret, false, nil
 }
 
 func (r *IronCoreReconciler) createBmc(ctx context.Context, device *models.Device, oobIP, hostname string, bmcSecret *metalv1alpha1.BMCSecret, labels map[string]string) (*metalv1alpha1.BMC, error) {
@@ -400,26 +409,6 @@ func (r *IronCoreReconciler) patchBMCLabels(ctx context.Context, bmc *metalv1alp
 	if err := r.k8sClient.Patch(ctx, bmc, client.MergeFrom(bmcBase)); err != nil {
 		logger.Error(err, "failed to patch BMC labels")
 		return err
-	}
-
-	if bmc.Spec.BMCSecretRef.Name != "" {
-		bmcSecret := &metalv1alpha1.BMCSecret{}
-
-		if err := r.k8sClient.Get(ctx, client.ObjectKey{Name: bmc.Spec.BMCSecretRef.Name}, bmcSecret); err != nil {
-			logger.Error(err, "failed to get BMC secret")
-			return err
-		}
-
-		bmcSecretBase := bmcSecret.DeepCopy()
-		if bmcSecret.Labels == nil {
-			bmcSecret.Labels = make(map[string]string)
-		}
-		maps.Copy(bmcSecret.Labels, labels)
-
-		if err := r.k8sClient.Patch(ctx, bmcSecret, client.MergeFrom(bmcSecretBase)); err != nil {
-			logger.Error(err, "failed to patch BMC secret labels")
-			return err
-		}
 	}
 
 	return nil

--- a/internal/controller/ironcore_controller.go
+++ b/internal/controller/ironcore_controller.go
@@ -35,9 +35,8 @@ import (
 )
 
 const (
-	bmcProtocolRedfish       = "Redfish"
-	bmcPort                  = 443
-	remoteboardInterfaceName = "remoteboard"
+	bmcProtocolRedfish = "Redfish"
+	bmcPort            = 443
 )
 
 type IronCoreReconciler struct {
@@ -192,7 +191,7 @@ func (r *IronCoreReconciler) reconcileDevice(ctx context.Context, netBox netbox.
 	logger := log.FromContext(ctx)
 	logger.Info("reconciling device", "device", device.Name, "ID", device.ID)
 
-	if device.Status.Value != "active" {
+	if device.Status.Value != deviceStatusActive {
 		logger.Info("device is not active, will skip", "status", device.Status.Value)
 		return nil
 	}
@@ -279,7 +278,7 @@ func (r *IronCoreReconciler) reconcileBmcSecret(ctx context.Context, device *mod
 	}
 
 	if err := r.k8sClient.Get(ctx, client.ObjectKeyFromObject(bmcSecret), bmcSecret); err == nil {
-		if bmcSecret.Annotations[argorav1alpha1.AnnotationIgnore] == "true" {
+		if bmcSecret.Annotations[argorav1alpha1.AnnotationIgnore] == annotationValueTrue {
 			logger.Info("BMCSecret has ignore annotation, skipping reconciliation", "name", bmcSecret.Name)
 			return bmcSecret, true, nil
 		}

--- a/internal/controller/ironcore_controller_test.go
+++ b/internal/controller/ironcore_controller_test.go
@@ -922,6 +922,216 @@ var _ = Describe("Ironcore Controller", func() {
 
 				expectStatus(argorav1alpha1.Ready, "")
 			})
+
+			It("should update BMCSecret when credentials change", func() {
+				// given
+				netBoxMock := prepareNetboxMock()
+				controllerReconciler := createIronCoreReconciler(k8sClient, netBoxMock, fileReaderMock)
+
+				// first reconcile creates BMCSecret with original credentials
+				res, err := controllerReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedClusterImportName})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(res.RequeueAfter).To(Equal(reconcileInterval))
+
+				// verify original credentials
+				bmcSecret := &metalv1alpha1.BMCSecret{}
+				err = k8sClient.Get(ctx, typeNamespacedBMCName1, bmcSecret)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(bmcSecret.Data[metalv1alpha1.BMCSecretUsernameKeyName]).To(Equal([]byte("user")))
+				Expect(bmcSecret.Data[metalv1alpha1.BMCSecretPasswordKeyName]).To(Equal([]byte("password")))
+
+				// simulate credential rotation
+				rotatedFileReaderMock := &mock.FileReaderMock{
+					FileContent: make(map[string]string),
+					ReturnError: false,
+				}
+				rotatedFileReaderMock.FileContent["/etc/credentials/credentials.json"] = `{
+					"bmcUser": "new-user",
+					"bmcPassword": "new-password",
+					"netboxToken": "token"
+				}`
+				controllerReconciler = createIronCoreReconciler(k8sClient, netBoxMock, rotatedFileReaderMock)
+
+				// when - second reconcile with rotated credentials
+				res, err = controllerReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedClusterImportName})
+
+				// then
+				Expect(err).ToNot(HaveOccurred())
+				Expect(res.RequeueAfter).To(Equal(reconcileInterval))
+
+				// verify credentials were updated
+				err = k8sClient.Get(ctx, typeNamespacedBMCName1, bmcSecret)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(bmcSecret.Data[metalv1alpha1.BMCSecretUsernameKeyName]).To(Equal([]byte("new-user")))
+				Expect(bmcSecret.Data[metalv1alpha1.BMCSecretPasswordKeyName]).To(Equal([]byte("new-password")))
+
+				expectStatus(argorav1alpha1.Ready, "")
+			})
+
+			It("should not update BMCSecret when credentials are unchanged", func() {
+				// given
+				netBoxMock := prepareNetboxMock()
+				controllerReconciler := createIronCoreReconciler(k8sClient, netBoxMock, fileReaderMock)
+
+				// first reconcile creates BMCSecret
+				res, err := controllerReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedClusterImportName})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(res.RequeueAfter).To(Equal(reconcileInterval))
+
+				// get the resource version after first reconcile
+				bmcSecret := &metalv1alpha1.BMCSecret{}
+				err = k8sClient.Get(ctx, typeNamespacedBMCName1, bmcSecret)
+				Expect(err).ToNot(HaveOccurred())
+				resourceVersionAfterCreate := bmcSecret.ResourceVersion
+
+				// when - second reconcile with same credentials
+				res, err = controllerReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedClusterImportName})
+
+				// then
+				Expect(err).ToNot(HaveOccurred())
+				Expect(res.RequeueAfter).To(Equal(reconcileInterval))
+
+				// verify no update occurred (resource version unchanged)
+				err = k8sClient.Get(ctx, typeNamespacedBMCName1, bmcSecret)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(bmcSecret.ResourceVersion).To(Equal(resourceVersionAfterCreate))
+
+				expectStatus(argorav1alpha1.Ready, "")
+			})
+
+			It("should update BMCSecret labels when they change", func() {
+				// given
+				netBoxMock := prepareNetboxMock()
+				controllerReconciler := createIronCoreReconciler(k8sClient, netBoxMock, fileReaderMock)
+
+				// first reconcile creates BMCSecret
+				res, err := controllerReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedClusterImportName})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(res.RequeueAfter).To(Equal(reconcileInterval))
+
+				// verify original labels
+				bmcSecret := &metalv1alpha1.BMCSecret{}
+				err = k8sClient.Get(ctx, typeNamespacedBMCName1, bmcSecret)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(bmcSecret.Labels).To(HaveKeyWithValue("kubernetes.metal.cloud.sap/cluster", "cluster1"))
+
+				// simulate cluster change
+				netBoxMock.VirtualizationMock.(*mock.VirtualizationMock).GetClustersByNameRegionTypeFunc = func(name, region, clusterType string) ([]models.Cluster, error) {
+					return []models.Cluster{
+						{
+							ID:   1,
+							Name: "cluster-new",
+							Type: models.NestedClusterType{
+								Slug: clusterType1,
+							},
+						},
+					}, nil
+				}
+
+				// when - second reconcile with different labels
+				res, err = controllerReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedClusterImportName})
+
+				// then
+				Expect(err).ToNot(HaveOccurred())
+				Expect(res.RequeueAfter).To(Equal(reconcileInterval))
+
+				// verify labels were updated
+				err = k8sClient.Get(ctx, typeNamespacedBMCName1, bmcSecret)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(bmcSecret.Labels).To(HaveKeyWithValue("kubernetes.metal.cloud.sap/cluster", "cluster-new"))
+
+				expectStatus(argorav1alpha1.Ready, "")
+			})
+
+			It("should skip BMCSecret with ignore annotation", func() {
+				// given
+				netBoxMock := prepareNetboxMock()
+				controllerReconciler := createIronCoreReconciler(k8sClient, netBoxMock, fileReaderMock)
+
+				// first reconcile creates BMCSecret
+				res, err := controllerReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedClusterImportName})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(res.RequeueAfter).To(Equal(reconcileInterval))
+
+				// add ignore annotation to BMCSecret
+				bmcSecret := &metalv1alpha1.BMCSecret{}
+				err = k8sClient.Get(ctx, typeNamespacedBMCName1, bmcSecret)
+				Expect(err).ToNot(HaveOccurred())
+				originalData := bmcSecret.Data
+				originalLabels := bmcSecret.Labels
+
+				bmcSecretBase := bmcSecret.DeepCopy()
+				bmcSecret.Annotations = map[string]string{
+					argorav1alpha1.AnnotationIgnore: "true",
+				}
+				Expect(k8sClient.Patch(ctx, bmcSecret, client.MergeFrom(bmcSecretBase))).To(Succeed())
+
+				// simulate credential rotation
+				rotatedFileReaderMock := &mock.FileReaderMock{
+					FileContent: make(map[string]string),
+					ReturnError: false,
+				}
+				rotatedFileReaderMock.FileContent["/etc/credentials/credentials.json"] = `{
+					"bmcUser": "rotated-user",
+					"bmcPassword": "rotated-password",
+					"netboxToken": "token"
+				}`
+				controllerReconciler = createIronCoreReconciler(k8sClient, netBoxMock, rotatedFileReaderMock)
+
+				// when - second reconcile with rotated credentials
+				res, err = controllerReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedClusterImportName})
+
+				// then
+				Expect(err).ToNot(HaveOccurred())
+				Expect(res.RequeueAfter).To(Equal(reconcileInterval))
+
+				// verify BMCSecret was NOT updated
+				err = k8sClient.Get(ctx, typeNamespacedBMCName1, bmcSecret)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(bmcSecret.Data).To(Equal(originalData))
+				Expect(bmcSecret.Labels).To(Equal(originalLabels))
+
+				expectStatus(argorav1alpha1.Ready, "")
+			})
+
+			It("should skip patchOwnerReference when BMCSecret is ignored", func() {
+				// given
+				netBoxMock := prepareNetboxMock()
+				controllerReconciler := createIronCoreReconciler(k8sClient, netBoxMock, fileReaderMock)
+
+				// pre-create BMCSecret with ignore annotation (no owner ref)
+				bmcSecret := &metalv1alpha1.BMCSecret{
+					ObjectMeta: ctrl.ObjectMeta{
+						Name: bmcName1,
+						Annotations: map[string]string{
+							argorav1alpha1.AnnotationIgnore: "true",
+						},
+					},
+					Data: map[string][]byte{
+						metalv1alpha1.BMCSecretUsernameKeyName: []byte("manual-user"),
+						metalv1alpha1.BMCSecretPasswordKeyName: []byte("manual-password"),
+					},
+				}
+				Expect(k8sClient.Create(ctx, bmcSecret)).To(Succeed())
+
+				// when
+				res, err := controllerReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedClusterImportName})
+
+				// then
+				Expect(err).ToNot(HaveOccurred())
+				Expect(res.RequeueAfter).To(Equal(reconcileInterval))
+
+				// verify BMCSecret has no owner reference (patchOwnerReference was skipped)
+				err = k8sClient.Get(ctx, typeNamespacedBMCName1, bmcSecret)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(bmcSecret.OwnerReferences).To(BeEmpty())
+
+				// verify credentials were NOT updated
+				Expect(bmcSecret.Data[metalv1alpha1.BMCSecretUsernameKeyName]).To(Equal([]byte("manual-user")))
+				Expect(bmcSecret.Data[metalv1alpha1.BMCSecretPasswordKeyName]).To(Equal([]byte("manual-password")))
+
+				expectStatus(argorav1alpha1.Ready, "")
+			})
 		})
 
 		Context("Fake Client", func() {
@@ -941,7 +1151,7 @@ var _ = Describe("Ironcore Controller", func() {
 				},
 			}
 
-			It("should return an error if createBmcSecret fails", func() {
+			It("should return an error if reconcileBmcSecret fails", func() {
 				// given
 				netBoxMock := prepareNetboxMock()
 
@@ -955,7 +1165,7 @@ var _ = Describe("Ironcore Controller", func() {
 
 				// then
 				Expect(err).To(HaveOccurred())
-				Expect(err).To(MatchError("unable to create bmc secret: intentionally failing client on client.Create for BMCSecret"))
+				Expect(err).To(MatchError("unable to reconcile bmc secret: intentionally failing client on client.Create for BMCSecret"))
 				Expect(res.RequeueAfter).To(Equal(0 * time.Second))
 			})
 
@@ -1047,7 +1257,14 @@ type shouldFailClient struct {
 }
 
 func (p *shouldFailClient) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
-	if obj.GetObjectKind().GroupVersionKind().Kind == p.FailOnCreateKind {
+	kind := obj.GetObjectKind().GroupVersionKind().Kind
+	if kind == "" {
+		gvks, _, _ := p.Scheme().ObjectKinds(obj)
+		if len(gvks) > 0 {
+			kind = gvks[0].Kind
+		}
+	}
+	if kind == p.FailOnCreateKind {
 		return errors.New("intentionally failing client on client.Create for " + p.FailOnCreateKind)
 	}
 	return p.Client.Create(ctx, obj, opts...)

--- a/internal/controller/metal3_controller.go
+++ b/internal/controller/metal3_controller.go
@@ -22,6 +22,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -30,6 +31,7 @@ import (
 	"github.com/sapcc/go-netbox-go/models"
 	"gopkg.in/yaml.v3"
 
+	argorav1alpha1 "github.com/sapcc/argora/api/v1alpha1"
 	"github.com/sapcc/argora/internal/credentials"
 	"github.com/sapcc/argora/internal/netbox"
 	"github.com/sapcc/argora/internal/networkdata"
@@ -209,16 +211,10 @@ func (r *Metal3Reconciler) reconcileDevice(ctx context.Context, cluster *cluster
 		return fmt.Errorf("unable to get region for device: %w", err)
 	}
 
-	bmcSecret, err := r.createBmcSecret(cluster, device)
+	bmcSecret, _, err := r.reconcileBmcSecret(ctx, cluster, device)
 	if err != nil {
-		return fmt.Errorf("unable to create bmc secret: %w", err)
+		return fmt.Errorf("unable to reconcile bmc secret: %w", err)
 	}
-
-	if err = r.k8sClient.Create(ctx, bmcSecret); err != nil {
-		return fmt.Errorf("unable to upload bmc secret: %w", err)
-	}
-
-	logger.Info("created BMC Secret", "name", bmcSecret.Name)
 
 	role, err := getRoleFromTags(device)
 	if err != nil {
@@ -358,24 +354,49 @@ func (r *Metal3Reconciler) createNetworkDataSecret(ctx context.Context, bareMeta
 	return r.k8sClient.Create(ctx, nwDataSecret)
 }
 
-func (r *Metal3Reconciler) createBmcSecret(cluster *clusterv1.Cluster, device *models.Device) (*corev1.Secret, error) {
+func (r *Metal3Reconciler) reconcileBmcSecret(ctx context.Context, cluster *clusterv1.Cluster, device *models.Device) (*corev1.Secret, bool, error) {
+	logger := log.FromContext(ctx)
+
 	user := r.credentials.BMCUser
 	password := r.credentials.BMCPassword
 
 	if user == "" || password == "" {
-		return nil, errors.New("bmc user or password not set")
+		return nil, false, errors.New("bmc user or password not set")
 	}
 
-	return &corev1.Secret{
+	bmcSecret := &corev1.Secret{
 		ObjectMeta: ctrl.ObjectMeta{
 			Name:      "bmc-secret-" + device.Name,
 			Namespace: cluster.Namespace,
 		},
-		StringData: map[string]string{
+	}
+
+	if err := r.k8sClient.Get(ctx, client.ObjectKeyFromObject(bmcSecret), bmcSecret); err == nil {
+		if bmcSecret.Annotations[argorav1alpha1.AnnotationIgnore] == "true" {
+			logger.Info("BMCSecret has ignore annotation, skipping reconciliation", "name", bmcSecret.Name)
+			return bmcSecret, true, nil
+		}
+	}
+
+	result, err := controllerutil.CreateOrUpdate(ctx, r.k8sClient, bmcSecret, func() error {
+		bmcSecret.StringData = map[string]string{
 			"username": user,
 			"password": password,
-		},
-	}, nil
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, false, err
+	}
+
+	switch result {
+	case controllerutil.OperationResultCreated:
+		logger.Info("created BMC Secret", "name", bmcSecret.Name)
+	case controllerutil.OperationResultUpdated:
+		logger.Info("BMC Secret credentials updated", "name", bmcSecret.Name)
+	}
+
+	return bmcSecret, false, nil
 }
 
 func createRedFishURL(device *models.Device) (string, error) {

--- a/internal/controller/metal3_controller.go
+++ b/internal/controller/metal3_controller.go
@@ -41,11 +41,11 @@ const ClusterRoleLabel = "discovery.inf.sap.cloud/clusterRole"
 
 var (
 	rootHintMap = map[string]string{
-		"poweredge-r660":             "BOSS",
-		"poweredge-r640":             "BOSS",
-		"poweredge-r840":             "BOSS",
-		"poweredge-r7615":            "BOSS",
-		"dell-poweredge-r7715":       "BOSS",
+		"poweredge-r660":             rootHintBOSS,
+		"poweredge-r640":             rootHintBOSS,
+		"poweredge-r840":             rootHintBOSS,
+		"poweredge-r7615":            rootHintBOSS,
+		"dell-poweredge-r7715":       rootHintBOSS,
 		"thinksystem-sr650":          "ThinkSystem M.2 VD",
 		"thinksystem-sr655-v3":       "NVMe 2-Bay",
 		"thinksystem-sr650-v3":       "NVMe 2-Bay",
@@ -174,7 +174,7 @@ func (r *Metal3Reconciler) reconcileDevice(ctx context.Context, cluster *cluster
 	logger := log.FromContext(ctx)
 	logger.Info("reconciling device", "device", device.Name, "ID", device.ID)
 
-	if device.Status.Value != "active" {
+	if device.Status.Value != deviceStatusActive {
 		logger.Info("device is not active", "status", device.Status.Value)
 		return nil
 	}
@@ -372,7 +372,7 @@ func (r *Metal3Reconciler) reconcileBmcSecret(ctx context.Context, cluster *clus
 	}
 
 	if err := r.k8sClient.Get(ctx, client.ObjectKeyFromObject(bmcSecret), bmcSecret); err == nil {
-		if bmcSecret.Annotations[argorav1alpha1.AnnotationIgnore] == "true" {
+		if bmcSecret.Annotations[argorav1alpha1.AnnotationIgnore] == annotationValueTrue {
 			logger.Info("BMCSecret has ignore annotation, skipping reconciliation", "name", bmcSecret.Name)
 			return bmcSecret, true, nil
 		}

--- a/internal/controller/metal3_controller_test.go
+++ b/internal/controller/metal3_controller_test.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	argorav1alpha1 "github.com/sapcc/argora/api/v1alpha1"
 	"github.com/sapcc/argora/internal/controller/mock"
 	"github.com/sapcc/argora/internal/credentials"
 	"github.com/sapcc/argora/internal/networkdata"
@@ -545,6 +546,102 @@ var _ = Describe("Metal3 Controller", func() {
 			// then
 			Expect(err).ToNot(HaveOccurred())
 			Expect(res.RequeueAfter).To(Equal(reconcileIntervalDefault))
+		})
+
+		It("should update BMC Secret when credentials change", func() {
+			// given
+			netBoxMock := prepareNetboxMock()
+			controllerReconciler := createMetal3Reconciler(k8sClient, netBoxMock, fileReaderMock)
+
+			// first reconcile creates the secret
+			res, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedClusterName,
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res.RequeueAfter).To(Equal(reconcileIntervalDefault))
+
+			// verify original credentials
+			bmcSecret := &corev1.Secret{}
+			err = k8sClient.Get(ctx, typeNamespacedSecretName, bmcSecret)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(bmcSecret.Data["username"]).To(Equal([]byte("user")))
+			Expect(bmcSecret.Data["password"]).To(Equal([]byte("password")))
+
+			// delete BareMetalHost so next reconcile goes through full path
+			bmh := &v1alpha1.BareMetalHost{}
+			err = k8sClient.Get(ctx, typeNamespacedBareMetalHostName, bmh)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(k8sClient.Delete(ctx, bmh)).To(Succeed())
+
+			// delete network data secret
+			ndSecret := &corev1.Secret{}
+			err = k8sClient.Get(ctx, typeNamespacedNDSecretName, ndSecret)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(k8sClient.Delete(ctx, ndSecret)).To(Succeed())
+
+			// simulate credential rotation
+			rotatedFileReaderMock := &mock.FileReaderMock{
+				FileContent: make(map[string]string),
+				ReturnError: false,
+			}
+			rotatedFileReaderMock.FileContent["/etc/credentials/credentials.json"] = `{
+				"bmcUser": "new-user",
+				"bmcPassword": "new-password",
+				"netboxToken": "token"
+			}`
+			controllerReconciler = createMetal3Reconciler(k8sClient, netBoxMock, rotatedFileReaderMock)
+
+			// when - second reconcile with rotated credentials
+			res, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedClusterName,
+			})
+
+			// then
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res.RequeueAfter).To(Equal(reconcileIntervalDefault))
+
+			// verify credentials were updated
+			err = k8sClient.Get(ctx, typeNamespacedSecretName, bmcSecret)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(bmcSecret.Data["username"]).To(Equal([]byte("new-user")))
+			Expect(bmcSecret.Data["password"]).To(Equal([]byte("new-password")))
+		})
+
+		It("should skip corev1.Secret with ignore annotation", func() {
+			// given
+			netBoxMock := prepareNetboxMock()
+			controllerReconciler := createMetal3Reconciler(k8sClient, netBoxMock, fileReaderMock)
+
+			// pre-create BMC secret with ignore annotation
+			bmcSecret := &corev1.Secret{
+				ObjectMeta: ctrl.ObjectMeta{
+					Name:      "bmc-secret-" + deviceName,
+					Namespace: clusterNamespace,
+					Annotations: map[string]string{
+						argorav1alpha1.AnnotationIgnore: "true",
+					},
+				},
+				StringData: map[string]string{
+					"username": "manual-user",
+					"password": "manual-password",
+				},
+			}
+			Expect(k8sClient.Create(ctx, bmcSecret)).To(Succeed())
+
+			// when
+			res, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedClusterName,
+			})
+
+			// then - reconcile succeeds (BareMetalHost is still created)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res.RequeueAfter).To(Equal(reconcileIntervalDefault))
+
+			// verify secret was NOT updated
+			err = k8sClient.Get(ctx, typeNamespacedSecretName, bmcSecret)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(bmcSecret.Data["username"]).To(Equal([]byte("manual-user")))
+			Expect(bmcSecret.Data["password"]).To(Equal([]byte("manual-password")))
 		})
 	})
 })

--- a/internal/controller/update_controller.go
+++ b/internal/controller/update_controller.go
@@ -184,7 +184,7 @@ func (r *UpdateReconciler) reconcileDevice(ctx context.Context, netBox netbox.Ne
 	logger := log.FromContext(ctx)
 	logger.Info("reconciling device", "device", device.Name, "ID", device.ID)
 
-	if !slices.Contains([]string{"active", "staged"}, device.Status.Value) {
+	if !slices.Contains([]string{deviceStatusActive, deviceStatusStaged}, device.Status.Value) {
 		logger.Info("device is neither active or staged, will skip", "status", device.Status.Value)
 		return nil
 	}
@@ -219,7 +219,7 @@ func (r *UpdateReconciler) renameRemoteboardInterface(ctx context.Context, netBo
 	for _, iface := range ifaces {
 		if slices.Contains(interfacesToRename, iface.Name) {
 			wIface := models.WritableInterface{
-				Name:   "remoteboard",
+				Name:   remoteboardInterfaceName,
 				Device: device.ID,
 				Type:   iface.Type.Value,
 			}
@@ -239,7 +239,7 @@ func (r *UpdateReconciler) renameRemoteboardInterface(ctx context.Context, netBo
 func (r *UpdateReconciler) updateDeviceData(ctx context.Context, netBox netbox.Netbox, device *models.Device) error {
 	logger := log.FromContext(ctx)
 
-	iface, err := netBox.DCIM().GetInterfaceForDevice(device, "remoteboard")
+	iface, err := netBox.DCIM().GetInterfaceForDevice(device, remoteboardInterfaceName)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

Fixes https://github.com/sapcc/argora/issues/159

Previously, `createBmcSecret` only created BMCSecrets — if one already existed it returned early without comparing or updating credentials. When IPMI credentials rotate in Vault, BMCSecrets on the metal cluster became stale.

## Changes

- **`api/v1alpha1/common.go`**: Add `AnnotationIgnore = "argora.cloud.sap/ignore"` constant
- **`internal/controller/ironcore_controller.go`**: `reconcileBmcSecret` now does Get → annotation check → CreateOrUpdate. Returns (secret, skipped, error) — caller skips patchOwnerReference when ignored.
- **`internal/controller/metal3_controller.go`**: Convert `createBmcSecret` → `reconcileBmcSecret` using `controllerutil.CreateOrUpdate`. Same ignore annotation support as ironcore.
- **Tests**: credential rotation, no-op on unchanged credentials, label updates, ignore annotation skip, owner reference skip

## Ignore Annotation

`argora.cloud.sap/ignore: "true"` on a BMCSecret prevents all controller writes to that resource (no data update, no label update, no owner ref patch). The controller still reads the resource to pass `.Name` to BMC's `BMCSecretRef`.
