### PR TITLE
fix(metal3): reconcile BMCSecret for existing BareMetalHosts

### DIFF
--- a/internal/controller/metal3_controller.go
+++ b/internal/controller/metal3_controller.go
@@ -179,6 +179,11 @@ func (r *Metal3Reconciler) reconcileDevice(ctx context.Context, cluster *cluster
 		return nil
 	}
 
+	bmcSecret, _, err := r.reconcileBmcSecret(ctx, cluster, device)
+	if err != nil {
+		return fmt.Errorf("unable to reconcile bmc secret: %w", err)
+	}
+
 	bmh := &bmov1alpha1.BareMetalHost{}
 	if err := r.k8sClient.Get(ctx, client.ObjectKey{Name: device.Name, Namespace: cluster.Namespace}, bmh); err == nil {
 		logger.Info("BareMetalHost custom resource already exists, will skip", "host", bmh.Name)
@@ -209,11 +214,6 @@ func (r *Metal3Reconciler) reconcileDevice(ctx context.Context, cluster *cluster
 	region, err := r.netBox.DCIM().GetRegionForDevice(device)
 	if err != nil {
 		return fmt.Errorf("unable to get region for device: %w", err)
-	}
-
-	bmcSecret, _, err := r.reconcileBmcSecret(ctx, cluster, device)
-	if err != nil {
-		return fmt.Errorf("unable to reconcile bmc secret: %w", err)
 	}
 
 	role, err := getRoleFromTags(device)
@@ -379,9 +379,9 @@ func (r *Metal3Reconciler) reconcileBmcSecret(ctx context.Context, cluster *clus
 	}
 
 	result, err := controllerutil.CreateOrUpdate(ctx, r.k8sClient, bmcSecret, func() error {
-		bmcSecret.StringData = map[string]string{
-			"username": user,
-			"password": password,
+		bmcSecret.Data = map[string][]byte{
+			"username": []byte(user),
+			"password": []byte(password),
 		}
 		return nil
 	})


### PR DESCRIPTION
## Problem

The metal3 controller's reconcileDevice returned early when a BareMetalHost already existed, skipping reconcileBmcSecret entirely. This meant:
- Credential rotation from credentials.json was never applied to existing devices
- Manual edits to BMC secrets were never corrected

## Fix

1. **Move reconcileBmcSecret before BMH existence check** — secrets are now always reconciled regardless of whether the BMH already exists (matching the ironcore controller pattern)
2. **Use Data instead of StringData** — StringData is write-only (never returned by the API), causing CreateOrUpdate to issue spurious updates every reconcile cycle. Using Data directly allows proper equality comparison, updating only when credentials actually change.