### PR TITLE
ServerWiring: only include CarrierStatus for interfaces that have a cable assigned

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -33,7 +33,7 @@ jobs:
           check-latest: true
           go-version: 1.26.5
       - name: Run prepare make target
-        run: make generate setup-envtest
+        run: make generate manifests setup-envtest check-manifests
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,7 +36,7 @@ jobs:
           check-latest: true
           go-version: 1.26.5
       - name: Run prepare make target
-        run: make generate setup-envtest
+        run: make generate manifests setup-envtest check-manifests
       - name: Build all binaries
         run: make build-all
   code_coverage:
@@ -76,7 +76,7 @@ jobs:
           check-latest: true
           go-version: 1.26.5
       - name: Run prepare make target
-        run: make generate setup-envtest
+        run: make generate manifests setup-envtest check-manifests
       - name: Run tests and generate coverage report
         run: make build/cover.out
       - name: Archive code coverage results

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -36,7 +36,7 @@ jobs:
           check-latest: true
           go-version: 1.26.5
       - name: Run prepare make target
-        run: make generate setup-envtest
+        run: make generate manifests setup-envtest check-manifests
       - name: Initialize CodeQL
         uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4
         with:

--- a/.license-scan-overrides.jsonl
+++ b/.license-scan-overrides.jsonl
@@ -1,6 +1,7 @@
 {"name": "github.com/chzyer/logex", "licenceType": "MIT"}
 {"name": "github.com/grpc-ecosystem/go-grpc-middleware/v2", "licenceType": "Apache-2.0"}
 {"name": "github.com/hashicorp/vault/api/auth/approle", "licenceType": "MPL-2.0"}
+{"name": "github.com/ironcore-dev/metal-maintenance-operator", "licenceType": "Apache-2.0"}
 {"name": "github.com/jpillora/longestcommon", "licenceType": "MIT"}
 {"name": "github.com/logrusorgru/aurora", "licenceType": "Unlicense"}
 {"name": "github.com/mattn/go-localereader", "licenceType": "MIT"}

--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,10 @@ help-ext: ## Display this help.
 manifests: controller-gen
 	"$(CONTROLLER_GEN)" rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 
+.PHONY: check-manifests
+check-manifests: manifests generate ## Check that generated manifests and code are up-to-date.
+	git diff --exit-code
+
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."

--- a/Makefile.maker.yaml
+++ b/Makefile.maker.yaml
@@ -17,7 +17,7 @@ golangciLint:
 githubWorkflow:
   ci:
     enabled: true
-    prepareMakeTarget: generate setup-envtest
+    prepareMakeTarget: generate manifests setup-envtest check-manifests
     ignorePaths:
       - "**.md" # all Markdown files
   pushContainerToGhcr:
@@ -138,6 +138,10 @@ verbatim: |
   .PHONY: manifests
   manifests: controller-gen
     "$(CONTROLLER_GEN)" rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+
+  .PHONY: check-manifests
+  check-manifests: manifests generate ## Check that generated manifests and code are up-to-date.
+    git diff --exit-code
 
   .PHONY: generate
   generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.

--- a/config/crd/bases/argora.cloud.sap_clusterimports.yaml
+++ b/config/crd/bases/argora.cloud.sap_clusterimports.yaml
@@ -45,11 +45,15 @@ spec:
             properties:
               clusters:
                 items:
+                  description: |-
+                    ClusterSelector is intentionally shared between ClusterImport and Update CRDs.
+                    Controller-specific fields (e.g. BMCCredentialsRef) are simply ignored by controllers that don't need them.
                   properties:
                     bmcCredentialsRef:
                       description: |-
-                        LocalObjectReference contains enough information to let you locate the
-                        referenced object inside the same namespace.
+                        BMCCredentialsRef optionally references a Secret (same namespace) containing
+                        bmcUser and bmcPassword keys to override central BMC credentials.
+                        Used by the ironcore controller; ignored by others.
                       properties:
                         name:
                           default: ""

--- a/config/crd/bases/argora.cloud.sap_updates.yaml
+++ b/config/crd/bases/argora.cloud.sap_updates.yaml
@@ -45,11 +45,15 @@ spec:
             properties:
               clusters:
                 items:
+                  description: |-
+                    ClusterSelector is intentionally shared between ClusterImport and Update CRDs.
+                    Controller-specific fields (e.g. BMCCredentialsRef) are simply ignored by controllers that don't need them.
                   properties:
                     bmcCredentialsRef:
                       description: |-
-                        LocalObjectReference contains enough information to let you locate the
-                        referenced object inside the same namespace.
+                        BMCCredentialsRef optionally references a Secret (same namespace) containing
+                        bmcUser and bmcPassword keys to override central BMC credentials.
+                        Used by the ironcore controller; ignored by others.
                       properties:
                         name:
                           default: ""

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -148,3 +148,15 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - readiness.metal.ironcore.dev
+  resources:
+  - serverwirings
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sapcc/argora
 
-go 1.26
+go 1.26.3
 
 require (
 	github.com/dspinhirne/netaddr-go/v2 v2.0.0

--- a/internal/controller/ironcore_controller.go
+++ b/internal/controller/ironcore_controller.go
@@ -486,10 +486,13 @@ func (r *IronCoreReconciler) reconcileServerWiring(ctx context.Context, device *
 		if iface.Name == remoteboardInterfaceName {
 			continue
 		}
-		interfaces = append(interfaces, mmov1alpha1.ExpectedInterface{
-			MACAddress:    strings.ToLower(iface.MacAddress),
-			CarrierStatus: "up",
-		})
+		expectedIface := mmov1alpha1.ExpectedInterface{
+			MACAddress: strings.ToLower(iface.MacAddress),
+		}
+		if iface.Cable.ID != 0 {
+			expectedIface.CarrierStatus = "up"
+		}
+		interfaces = append(interfaces, expectedIface)
 	}
 
 	name := device.Name + "-serverwiring"

--- a/internal/controller/ironcore_controller_test.go
+++ b/internal/controller/ironcore_controller_test.go
@@ -1476,6 +1476,7 @@ var _ = Describe("Ironcore Controller", func() {
 				MacAddress: "52:54:00:de:59:65",
 				Type:       models.InterfaceType{Value: "1000base-t"},
 				MgmtOnly:   false,
+				Cable:      models.NestedCable{ID: 42},
 			}
 
 			prepareNetboxMockWithInterfaces := func(ifaces []models.Interface) *mock.NetBoxMock {
@@ -1526,6 +1527,32 @@ var _ = Describe("Ironcore Controller", func() {
 				Expect(src.Spec.Network.Interfaces[0].MACAddress).To(Equal("52:54:00:de:59:65"))
 				Expect(src.Spec.Network.Interfaces[0].CarrierStatus).To(Equal("up"))
 				Expect(src.Spec.ServerRef.Name).To(Equal(bmcName1 + "-system-0"))
+			})
+
+			It("should omit CarrierStatus for interfaces without a cable", func() {
+				// given
+				uncabledIface := models.Interface{
+					Name:       "enp0s3",
+					MacAddress: "52:54:00:de:59:66",
+					Type:       models.InterfaceType{Value: "1000base-t"},
+				}
+				netBoxMock := prepareNetboxMockWithInterfaces([]models.Interface{uncabledIface})
+				fakeClient := createFakeClient(clusterImportCR)
+				controllerReconciler := createIronCoreReconcilerWithReadiness(fakeClient, netBoxMock, fileReaderMock, []string{"serverwiring"})
+
+				// when
+				_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedClusterImportName})
+
+				// then
+				Expect(err).ToNot(HaveOccurred())
+
+				src := &mmov1alpha1.ServerWiring{}
+				err = fakeClient.Get(ctx, client.ObjectKey{Name: bmcName1 + "-serverwiring", Namespace: resourceNamespace}, src)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(src.Spec.Network.Interfaces).To(HaveLen(1))
+				Expect(src.Spec.Network.Interfaces[0].MACAddress).To(Equal("52:54:00:de:59:66"))
+				Expect(src.Spec.Network.Interfaces[0].CarrierStatus).To(BeEmpty())
 			})
 
 			It("should filter out mgmt-only, LAG, no-MAC, and remoteboard interfaces", func() {


### PR DESCRIPTION
- Only set CarrierStatus: "up" on ExpectedInterface entries when the interface has an explicit cable assigned in Netbox (Cable.ID != 0). Interfaces without a cable should not assert carrier state, as Netbox has no information about whether they are connected.
- Add a check-manifests make target that regenerates CRDs/RBAC and asserts git diff --exit-code, wired into all CI workflows to prevent stale generated files from merging.
- Update the manifests